### PR TITLE
SLING-12676 - Exception in initializing ResourceAccessSecurity with m…

### DIFF
--- a/src/main/java/org/apache/sling/resourceaccesssecurity/impl/ResourceAccessSecurityImpl.java
+++ b/src/main/java/org/apache/sling/resourceaccesssecurity/impl/ResourceAccessSecurityImpl.java
@@ -46,7 +46,7 @@ public abstract class ResourceAccessSecurityImpl implements ResourceAccessSecuri
             ComponentContext componentContext, String resourceAccessGateReferenceName) {
         this.defaultAllowIfNoGateMatches = defaultAllowIfNoGateMatches;
         // sort from highest ranked service to lowest ranked (opposite of default sorting of ServiceReference)
-        this.allHandlers = resourceAccessGateRefs.stream().map(ref -> new ResourceAccessGateHandler(ref, componentContext.locateService(resourceAccessGateReferenceName, ref))).sorted(Collections.reverseOrder()).collect(Collectors.toList());
+        this.allHandlers = resourceAccessGateRefs.stream().sorted(Collections.reverseOrder()).map(ref -> new ResourceAccessGateHandler(ref, componentContext.locateService(resourceAccessGateReferenceName, ref))).collect(Collectors.toList());
     }
 
 

--- a/src/test/java/org/apache/sling/resourceaccesssecurity/impl/ResourceAccessSecurityImplTests.java
+++ b/src/test/java/org/apache/sling/resourceaccesssecurity/impl/ResourceAccessSecurityImplTests.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
+import java.util.Arrays;
 
 import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.api.resource.Resource;
@@ -38,12 +39,43 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
+import static org.junit.Assert.fail;
 
 public class ResourceAccessSecurityImplTests {
 
     ServiceReference<ResourceAccessGate> serviceReference;
     ResourceAccessSecurity resourceAccessSecurity;
     ResourceAccessGate resourceAccessGate;
+
+
+    @Test
+    public void testInitWithMultipleGates() {
+
+        ServiceReference<ResourceAccessGate> serviceReference = mock(ServiceReference.class);
+        ResourceAccessGate resourceAccessGate = mock(ResourceAccessGate.class);
+
+        ServiceReference<ResourceAccessGate> serviceReference2 = mock(ServiceReference.class);
+        ResourceAccessGate resourceAccessGate2 = mock(ResourceAccessGate.class);
+
+        // Mock the service references to have different rankings
+        when(serviceReference.compareTo(serviceReference2)).thenReturn(-1);
+        when(serviceReference2.compareTo(serviceReference)).thenReturn(1);
+
+        ComponentContext context = mock(ComponentContext.class);
+        when(context.locateService(Mockito.anyString(), Mockito.eq(serviceReference))).thenReturn(resourceAccessGate);
+        when(context.locateService(Mockito.anyString(), Mockito.eq(serviceReference2))).thenReturn(resourceAccessGate2);
+
+        try {
+            resourceAccessSecurity = new ProviderResourceAccessSecurityImpl(
+                Arrays.asList(serviceReference, serviceReference2),
+                context);
+
+            // Verify that the gates are sorted in reverse order
+            verify(serviceReference).compareTo(serviceReference2);
+        } catch (Exception e) {
+            fail("Should not throw exception: " + e.getMessage());
+        }
+    }
 
     @Test
     public void testCanUpdate(){

--- a/src/test/java/org/apache/sling/resourceaccesssecurity/impl/ResourceAccessSecurityImplTests.java
+++ b/src/test/java/org/apache/sling/resourceaccesssecurity/impl/ResourceAccessSecurityImplTests.java
@@ -57,10 +57,6 @@ public class ResourceAccessSecurityImplTests {
         ServiceReference<ResourceAccessGate> serviceReference2 = mock(ServiceReference.class);
         ResourceAccessGate resourceAccessGate2 = mock(ResourceAccessGate.class);
 
-        // Mock the service references to have different rankings
-        when(serviceReference.compareTo(serviceReference2)).thenReturn(-1);
-        when(serviceReference2.compareTo(serviceReference)).thenReturn(1);
-
         ComponentContext context = mock(ComponentContext.class);
         when(context.locateService(Mockito.anyString(), Mockito.eq(serviceReference))).thenReturn(resourceAccessGate);
         when(context.locateService(Mockito.anyString(), Mockito.eq(serviceReference2))).thenReturn(resourceAccessGate2);
@@ -69,9 +65,6 @@ public class ResourceAccessSecurityImplTests {
             resourceAccessSecurity = new ProviderResourceAccessSecurityImpl(
                 Arrays.asList(serviceReference, serviceReference2),
                 context);
-
-            // Verify that the gates are sorted in reverse order
-            verify(serviceReference).compareTo(serviceReference2);
         } catch (Exception e) {
             fail("Should not throw exception: " + e.getMessage());
         }


### PR DESCRIPTION
…ultiple ResourceAccessGate refs

This PR fixes the exception thrown while initializing ResourceAccessSecurity with multiple ResourceAccessGate refs

```
Caused by: java.lang.ClassCastException: class org.apache.sling.resourceaccesssecurity.impl.ResourceAccessGateHandler cannot be cast to class java.lang.Comparable (org.apache.sling.resourceaccesssecurity.impl.ResourceAccessGateHandler is in unnamed module of loader org.apache.felix.framework.BundleWiringImpl$BundleClassLoader @45037a0c; java.lang.Comparable is in module java.base of loader 'bootstrap')
        at java.base/java.util.Collections$ReverseComparator.compare(Collections.java:5554)
        at java.base/java.util.TimSort.countRunAndMakeAscending(TimSort.java:355)
        at java.base/java.util.TimSort.sort(TimSort.java:220)
        at java.base/java.util.Arrays.sort(Arrays.java:1308)
        at java.base/java.util.stream.SortedOps$SizedRefSortingSink.end(SortedOps.java:353)
        at java.base/java.util.stream.Sink$ChainedReference.end(Sink.java:261)
```